### PR TITLE
Feature/add ci

### DIFF
--- a/.circleci/check-build-output-for-errors.sh
+++ b/.circleci/check-build-output-for-errors.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [ grep -iq error ~/repo/npm-build-output.txt ]
+then
+    exit 0
+else
+    grep -i error ~/repo/npm-build-output.txt
+    exit 1
+fi

--- a/.circleci/check-build-output-for-errors.sh
+++ b/.circleci/check-build-output-for-errors.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-if [ grep -iq error ~/repo/npm-build-output.txt ]
+grep -i error ~/repo/npm-build-output.txt
+if [ $? -eq 0 ]
 then
-    exit 0
-else
-    grep -i error ~/repo/npm-build-output.txt
     exit 1
+else
+    exit 0
 fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,72 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:9.11
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - run: git clone https://github.com/DataWorks-NC/quality-of-life-dashboard.git .
+      - checkout:
+          path: ~/repo/data
+      - run: sed -i "s/MAPBOX_ACCESS_TOKEN/$MAPBOX_ACCESS_TOKEN/" .circleci/config.private.js
+      - run: cp ./.circleci/config.private.js data/config/private.js
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+      # Manual fix for error in Mapbox GL SDK, see https://github.com/mapbox/mapbox-sdk-js/issues/181
+      - run: sed -i 's_'\''rest'\''_'\''rest/browser.js'\''_' node_modules/mapbox/lib/client.js
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: npm run build
+      - run: mkdir /tmp/workspace
+      - persist_to_workspace:
+          root: .
+          paths:
+            - public/*
+  deploy:
+    docker:
+      - image: circleci/node:9.11
+    working-directory: ~/repo
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: sudo apt-get install --upgrade -qq groff less python-dev python-pip
+      - run: pip install --upgrade --user awscli
+      - run: ~/.local/bin/aws s3 rm --recursive $AWS_S3_BUCKET
+      - run: ~/.local/bin/aws s3 cp --recursive /tmp/workspace/public/ $AWS_S3_BUCKET --exclude "*" --include "*.js" --include "*.json" --include "*.geojson" --include "*.html" --include "*.css" --include "*.png" --include "*.zip"
+      - run: ~/.local/bin/aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_ID  --paths "/*"
+
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,8 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       # run tests!
-      - run: npm run build
+      - run: npm run build > npm-build-output.txt
+      - run: ~/repo/data/.circleci/check-build-output-for-errors.sh
       - run: mkdir /tmp/workspace
       - persist_to_workspace:
           root: .

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ yarn.lock
 
 # scripts
 *.sh
+!check-build-output-for-errors.sh
 
 config/private.js
 .DS_Store


### PR DESCRIPTION
This PR adds CircleCI to the data repo as well, so that any new PR on the data repo will get a test build, and new pushes to `master` (or merged PRs) will get deployed.

**Also** differently from the main dashboard repo, on this repo, the  CircleCI build will fail if it finds  any errors in the `datagen.js` or `report-datagen.js` command.


