### PR TITLE
Minor tweaks to data config

### DIFF
--- a/config/data.js
+++ b/config/data.js
@@ -473,7 +473,7 @@ let dataConfig = {
   },
   "mPTGNRL": {
     "metric": "PTGNRL",
-    "category": "Engagement",
+    "category": "Civic Engagement",
     "title": "General Election Participation",
     "suffix": "%",
     "raw_label": "voters",
@@ -510,7 +510,7 @@ let dataConfig = {
   },
   "mPTPRIM": {
     "metric": "PTPRIM",
-    "category": "Engagement",
+    "category": "Civic Engagement",
     "title": "Primary Election Participation",
     "suffix": "%",
     "raw_label": "voters",

--- a/config/map.js
+++ b/config/map.js
@@ -25,7 +25,7 @@
 
 
 let mapConfig = {
-    style: "http://osm-liberty.lukasmartinelli.ch/style.json",
+    style: "https://osm-liberty.lukasmartinelli.ch/style.json",
     zoomEmbed: 9.5,
     zoom: 9.3,
     centerEmbed: [-78.907222,35.988611],

--- a/config/site.js
+++ b/config/site.js
@@ -77,14 +77,14 @@ let siteConfig = {
       },
       description: 'Description of Blockgroups',
     },
-    {
-      id: 'neighborhood',
-      name: 'Neighborhoods',
-      label: function(id) {
-        return id;
-      },
-      description: 'Description of Neighborhoods',
-    },
+    // {
+    //   id: 'neighborhood',
+    //   name: 'Neighborhoods',
+    //   label: function(id) {
+    //     return id;
+    //   },
+    //   description: 'Description of Neighborhoods',
+    // },
   ],
 
   // Report config.


### PR DESCRIPTION
@JohnKilleen this PR renames `Engagement` to `Civic Engagement`, disables neighborhood-level metrics, and fixes an http/https mixed content error.