### PR TITLE
Fix tract/blockgroup labeling bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,9 +66,6 @@ jobs:
           command: pip install -r .circleci/requirements.txt
           working_directory: /tmp/workspace/
       - run:
-          command: cp .circleci/robots.txt public/robots.txt
-          working_directory: /tmp/workspace/
-      - run:
           command: python .circleci/deploy.py /tmp/workspace/public
           working_directory: /tmp/workspace/
           environment:
@@ -82,6 +79,9 @@ jobs:
       - run:
           command: pip install -r .circleci/requirements.txt
           working_directory: /tmp/workspace/
+
+      # Copy production robots.txt file.
+      - run: cp /tmp/workspace/.circleci/robots-prod.txt /tmp/workspace/public/robots.txt
       - run:
           command: python .circleci/deploy.py /tmp/workspace/public
           working_directory: /tmp/workspace/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
 
     steps:
       - run: git clone https://github.com/DataWorks-NC/quality-of-life-dashboard.git .
+      - run: git checkout master
       - checkout:
           path: ~/repo/data
       - run: sed -i "s/MAPBOX_ACCESS_TOKEN/$MAPBOX_ACCESS_TOKEN/" .circleci/config.private.js

--- a/config/private.js.example
+++ b/config/private.js.example
@@ -1,6 +1,7 @@
 let privateConfig = {
   mapboxAccessToken: "MAPBOX_ACCESS_TOKEN",
   rollbarAccessToken: "ROLLBAR_ACCESS_TOKEN",
+  environment: process.env.NODE_ENV,
 };
 
 module.exports = privateConfig;

--- a/config/site.js
+++ b/config/site.js
@@ -91,7 +91,7 @@ let siteConfig = {
       id: 'tract',
       name: 'Census Tracts',
       label: function(id) {
-        let decimalPart = Number(id.substring(id.length-2));
+        let decimalPart = id.substring(id.length-2);
         return "Tract " + Number(id.substring(id.length-6, id.length-2)) + (decimalPart ? "." + decimalPart : '');
       },
       description: 'Description of tracts',
@@ -100,8 +100,8 @@ let siteConfig = {
       id: 'blockgroup',
       name: 'Census Blockgroups',
       label: function(id) {
-        let decimalPart = Number(id.substring(id.length-3, id.length-1));
-        return "Tract " + Number(id.substring(id.length-7, id.length-3)) + (decimalPart ? "." + decimalPart : '') + ", Block Group " + Number(id.substring(id.length-1));
+        let decimalPart = id.substring(id.length-3, id.length-1);
+        return "Tract " + Number(id.substring(id.length-7, id.length-3)) + (decimalPart ? "." + decimalPart : '') + ", Block Group " + id.substring(id.length-1);
       },
       description: 'Description of Blockgroups',
     },


### PR DESCRIPTION
This PR fixes a bug where in the compass tracts were labeled, for example, `18.9` instead of `18.09`.