### PR TITLE
config homebuyer income to economy

### DIFF
--- a/config/data.js
+++ b/config/data.js
@@ -467,7 +467,7 @@ module.exports = {
   },
   'mHMINC': {
     'metric': 'HMINC',
-    'category': 'Housing',
+    'category': 'Economy',
     'title': 'Median Homebuyer Income',
     'title_es': 'Mediana del Ingreso de los Compradores de Vivienda',
     'prefix': '$',


### PR DESCRIPTION
Moved median homebuyer income to the economy category for ease of comparing with median household income.